### PR TITLE
Fixes a `KeyError` when the cluster contains pools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+venv
+__pycache__
+.venv

--- a/maintenance-mode.py
+++ b/maintenance-mode.py
@@ -69,6 +69,8 @@ class Cluster:
         count = 0
         cpu_load_temp = 0
         for _ in self.cluster_information:
+            if _["type"] == "pool":
+                continue
             if _["status"] == "online":
                 count += 1
                 self.max_mem += int(_["maxmem"])  # Всего ОЗУ в кластере

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+certifi==2021.10.8
+charset-normalizer==2.0.12
+idna==3.3
+prettytable==3.3.0
+pyttsx3==2.90
+requests==2.27.1
+urllib3==1.26.9
+wcwidth==0.2.5


### PR DESCRIPTION
When a cluster has one or more pools configured, they are returned in the `/api2/json/cluster/resources` endpoint along with the list of VMs. This causes a `KeyError`, as the `pool` objects do not have a `status` field.
This fix checks for and ignores pools.
I also added a `requirements.txt`.

For example:

```json
{
  "data": [
    {
      "type": "pool",
      "cpu": 0.0488634206736965,
      "pool": "critical",
      "maxmem": 41875931136,
      "mem": 30204659946,
      "id": "/pool/critical",
      "maxcpu": 16,
      "uptime": 637030
    },
    {
      "node": "prox03",
      "id": "qemu/100",
      "hastate": "started",
      "uptime": 551319,
      "maxdisk": 21474836480,
      "name": "kube01",
      "vmid": 100,
      "type": "qemu",
      "diskwrite": 58090037248,
      "netin": 6295465475,
      "netout": 5716984801,
      "diskread": 481133056,
      "maxcpu": 2,
      "disk": 0,
      "pool": "critical",
      "cpu": 0.0828981259730304,
      "maxmem": 4294967296,
      "mem": 3877625856,
      "template": 0,
      "status": "running"
    }
}
```